### PR TITLE
Created 2 new classes and 1 interface

### DIFF
--- a/src/main/java/com/example/HockeyStandings/base/BaseRequest.java
+++ b/src/main/java/com/example/HockeyStandings/base/BaseRequest.java
@@ -1,0 +1,53 @@
+package com.example.HockeyStandings.base;
+
+import javax.validation.constraints.NotNull;
+import java.io.Serializable;
+import java.util.Objects;
+
+public class BaseRequest implements Serializable{
+    public static class Id implements Serializable {
+        @NotNull
+        private Long id;
+
+        public Long getId() {
+            return id;
+        }
+
+        public void setId(Long id) {
+            this.id = id;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof Id)) return false;
+            Id id1 = (Id) o;
+            return Objects.equals(id, id1.id);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(id);
+        }
+    }
+    public static class GenId<T> implements Serializable{
+        @NotNull
+        private T id;
+        public T getId(){
+            return this.id;
+        }
+        public void setId(T id){
+            this.id=id;
+        }
+    }
+    public static class GenValue<T> implements Serializable{
+        @NotNull
+        private T value;
+        public T getValue(){
+            return value;
+        }
+        public void setValue(T value){
+            this.value=value;
+        }
+    }
+}

--- a/src/main/java/com/example/HockeyStandings/config/MessageConfig.java
+++ b/src/main/java/com/example/HockeyStandings/config/MessageConfig.java
@@ -1,0 +1,16 @@
+package com.example.HockeyStandings.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.ReloadableResourceBundleMessageSource;
+
+@Configuration
+public class MessageConfig {
+    @Bean(name="messageSource")
+    public ReloadableResourceBundleMessageSource messageSource(){
+        ReloadableResourceBundleMessageSource messageBundle=new ReloadableResourceBundleMessageSource();
+        messageBundle.setBasename("classpath:Messages");
+        messageBundle.setDefaultEncoding("UTF-8");
+        return messageBundle;
+    }
+}

--- a/src/main/java/com/example/HockeyStandings/error/ApiError.java
+++ b/src/main/java/com/example/HockeyStandings/error/ApiError.java
@@ -1,0 +1,6 @@
+package com.example.HockeyStandings.error;
+
+import java.io.Serializable;
+
+public interface ApiError extends Serializable{
+}


### PR DESCRIPTION
In this pull request, the following changes have been made
1. ```BaseRequest``` class is created in the ```com.example.HockeyStandings.base``` package.
2. ```MessageConfig``` class is created in the ```com.example.HockeyStandings.config``` package.
3.  ```ApiError``` is created in the ```com.example.HockeyStandings.error``` package.